### PR TITLE
justify-end send button, fix input border radius, fix sending empty

### DIFF
--- a/apps/www/src/components/new-chat.tsx
+++ b/apps/www/src/components/new-chat.tsx
@@ -180,7 +180,7 @@ export default function NewChat({
                   <FormItem className="space-y-2">
                     <FormMessage />
                     <FormControl>
-                      <div className="relative flex items-center">
+                      <div className="relative flex items-end">
                         <TextareaAutosize
                           {...field}
                           placeholder="Write a message..."
@@ -188,6 +188,14 @@ export default function NewChat({
                           onKeyDown={async (e) => {
                             if (e.key === "Enter" && !e.shiftKey) {
                               e.preventDefault();
+
+                              const message =
+                                form.watch("message").trim().length === 0;
+
+                              if (message === true) {
+                                return;
+                              }
+
                               await form.handleSubmit(async (values) => {
                                 setMessages((prev) => [
                                   ...prev,
@@ -207,7 +215,7 @@ export default function NewChat({
                           }}
                           rows={1}
                           maxRows={3}
-                          className="w-full resize-none rounded-full border-input bg-background px-4 py-2 text-base text-foreground ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                          className="w-full resize-none rounded-md border-input bg-background px-4 py-2 text-base text-foreground ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
                         />
                         <Button
                           type="submit"

--- a/apps/www/src/components/room-page.tsx
+++ b/apps/www/src/components/room-page.tsx
@@ -544,6 +544,13 @@ export default function RoomPageClient(
                           onKeyDown={async (e) => {
                             if (e.key === "Enter" && !e.shiftKey) {
                               e.preventDefault();
+
+                              const message =
+                                form.watch("message").trim().length === 0;
+
+                              if (message === true) {
+                                return;
+                              }
                               console.log("first");
                               await handleSubmit(form.getValues());
                             }

--- a/apps/www/src/components/room-page.tsx
+++ b/apps/www/src/components/room-page.tsx
@@ -536,7 +536,7 @@ export default function RoomPageClient(
                   <FormItem className="space-y-2">
                     <FormMessage />
                     <FormControl>
-                      <div className="relative flex items-center">
+                      <div className="relative flex items-end">
                         <TextareaAutosize
                           {...field}
                           placeholder="Write a message..."
@@ -544,13 +544,13 @@ export default function RoomPageClient(
                           onKeyDown={async (e) => {
                             if (e.key === "Enter" && !e.shiftKey) {
                               e.preventDefault();
-
+                              console.log("first");
                               await handleSubmit(form.getValues());
                             }
                           }}
                           rows={1}
                           maxRows={3}
-                          className="w-full resize-none rounded-full border-input bg-background px-4 py-2 text-base text-foreground ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                          className="w-full resize-none rounded-md border-input bg-background px-4 py-2 text-base text-foreground ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
                         />
                         <Button
                           type="submit"


### PR DESCRIPTION
Fixed rounded radius for text area, and made the button justify to the end of the div
![image](https://github.com/user-attachments/assets/f5dde9dc-d0f8-4ba9-bf46-4ee2a31ac167)

Prevents sending empty upon pressing "enter" only without any other characters. but still sends the message when you type spaces on it
![image](https://github.com/user-attachments/assets/54cccecf-1211-414b-ac70-992041b25ed4)

Suggestion for better fix:
disable onKeyDown when text input is not valid, the same as how the button is disabled.