### PR TITLE
Open privacy, terms, and external links in new tabs (in the landing page endpoint). Heads up: I modified the bento-grid component for this to work.

### DIFF
--- a/apps/www/src/components/home-public.tsx
+++ b/apps/www/src/components/home-public.tsx
@@ -278,11 +278,21 @@ export default function HomePublic({
               <span className="">By signing in, you agree to our </span>
               <br />
               <Button asChild variant="link" className="h-auto p-0">
-                <Link href="/terms">Terms of Service</Link>
+                <Link 
+                  href="/terms"
+                  target="_blank"
+                >
+                  Terms of Service
+                </Link>
               </Button>
               <span> and </span>
               <Button asChild variant="link" className="h-auto p-0">
-                <Link href="/privacy">Privacy Policy</Link>
+                <Link 
+                  href="/privacy"
+                  target="_blank"
+                >
+                  Privacy Policy
+                </Link>
               </Button>
               <span>.</span>
             </p>

--- a/packages/ui/src/magicui/bento-grid.tsx
+++ b/packages/ui/src/magicui/bento-grid.tsx
@@ -69,7 +69,7 @@ const BentoCard = ({
       )}
     >
       <Button variant="ghost" asChild size="sm" className="pointer-events-auto">
-        <a href={href}>
+        <a href={href} target="_blank">
           {cta}
           <ArrowRightIcon className="ml-2 h-4 w-4" />
         </a>


### PR DESCRIPTION
1. I think it would be better if the links would load in a different page so the users can still view the landing page.

2. I am from PUP Sta. Mesa. I am still figuring out how to make this work on my machine so I am not sure if this would work. 

3. I also found some vulnerabilities with regards to the headers and the lack of csrf and anti-clickjacking mechanisms. I will update you once I am successful in creating a proof of concept if this is really an exploit or just a false alarm.