### PR TITLE
Additional fix for replies in comments router

### DIFF
--- a/packages/api/src/routers/comments.ts
+++ b/packages/api/src/routers/comments.ts
@@ -220,7 +220,7 @@ export const commentsRouter = router({
     .input(
       z.object({
         comment_id: z.string().min(1),
-        content: z.string().min(1, { message: "Reply cannot be empty." }),
+        content: z.string().trim().min(1, { message: "Reply cannot be empty." }),
         post_id: z.string().min(1),
         level: z.number().int().nonnegative(),
       }),


### PR DESCRIPTION
Accidentally missed this yesterday. This can be considered as an addition to #119. This also trims the trailing whitespaces for replies in the comments router API.